### PR TITLE
Add missing Solidity keywords

### DIFF
--- a/languages/solidity/highlights.scm
+++ b/languages/solidity/highlights.scm
@@ -155,7 +155,13 @@
   "error"
   "fallback"
   "receive"
+  "as"
+  (unchecked)
   (virtual)
+] @keyword
+
+[
+  "transient"
 ] @keyword
 
 [
@@ -165,8 +171,7 @@
   "interface"
 ] @keyword.type
 
-; FIXME: update grammar
-; (block_statement "unchecked" @keyword)
+
 (event_parameter
   "indexed" @keyword)
 


### PR DESCRIPTION
- Add 'unchecked' keyword for unchecked math blocks
- Add 'as' keyword for type casting and other contexts
- Add 'transient' keyword for transient storage variables
- Remove outdated FIXME comment for unchecked keyword