### PR TITLE
Add test detection and documentation

### DIFF
--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,0 +1,226 @@
+// Project tasks configuration. See https://zed.dev/docs/tasks for documentation.
+//
+// Solidity Task Templates for Zed
+// Copy the tasks for your framework to your project's .zed/tasks.json
+//
+// Available frameworks:
+// - Foundry (Forge)
+// - Hardhat
+// - Truffle
+// - Brownie
+// - Security Tools (Slither, Mythril, Solhint)
+
+[
+  // ============================================================================
+  // FOUNDRY (Forge)
+  // ============================================================================
+  {
+    "label": "forge test: $ZED_SYMBOL",
+    "command": "forge",
+    "args": ["test", "--match-test", "$ZED_SYMBOL", "-vvvvv"],
+    "tags": ["foundry", "test", "symbol"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+  {
+    "label": "forge test: $ZED_SYMBOL (contract)",
+    "command": "forge",
+    "args": ["test", "--match-contract", "$ZED_SYMBOL", "-vvvvv"],
+    "tags": ["foundry", "test", "contract"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+  {
+    "label": "forge test: current file",
+    "command": "forge",
+    "args": ["test", "--match-path", "$ZED_FILE", "-vvvvv"],
+    "tags": ["foundry", "test", "file"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+  {
+    "label": "forge test: all tests",
+    "command": "forge",
+    "args": ["test", "-vvvvv"],
+    "tags": ["foundry", "test", "all"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+
+  // ============================================================================
+  // HARDHAT
+  // ============================================================================
+  {
+    "label": "hardhat test: test by name",
+    "command": "npx",
+    "args": ["hardhat", "test", "--grep", "$ZED_SYMBOL"],
+    "tags": ["hardhat", "test", "symbol"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+  {
+    "label": "hardhat test: contract tests",
+    "command": "npx",
+    "args": ["hardhat", "test", "--grep", "$ZED_SYMBOL"],
+    "tags": ["hardhat", "test", "contract"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+  {
+    "label": "hardhat test: current file",
+    "command": "npx",
+    "args": ["hardhat", "test", "$ZED_FILE"],
+    "tags": ["hardhat", "test", "file"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+  {
+    "label": "hardhat test: all tests",
+    "command": "npx",
+    "args": ["hardhat", "test"],
+    "tags": ["hardhat", "test", "all"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+
+  // ============================================================================
+  // TRUFFLE
+  // ============================================================================
+  {
+    "label": "truffle test: test by name",
+    "command": "truffle",
+    "args": ["test", "--grep", "$ZED_SYMBOL"],
+    "tags": ["truffle", "test", "symbol"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+  {
+    "label": "truffle test: contract tests",
+    "command": "truffle",
+    "args": ["test", "--grep", "$ZED_SYMBOL"],
+    "tags": ["truffle", "test", "contract"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+  {
+    "label": "truffle test: current file",
+    "command": "truffle",
+    "args": ["test", "$ZED_FILE"],
+    "tags": ["truffle", "test", "file"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+  {
+    "label": "truffle test: all tests",
+    "command": "truffle",
+    "args": ["test"],
+    "tags": ["truffle", "test", "all"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+
+  // ============================================================================
+  // BROWNIE
+  // ============================================================================
+  {
+    "label": "brownie test: test by name",
+    "command": "brownie",
+    "args": ["test", "-k", "$ZED_SYMBOL"],
+    "tags": ["brownie", "test", "symbol"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+  {
+    "label": "brownie test: contract tests",
+    "command": "brownie",
+    "args": ["test", "-k", "$ZED_SYMBOL"],
+    "tags": ["brownie", "test", "contract"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+  {
+    "label": "brownie test: current file",
+    "command": "brownie",
+    "args": ["test", "$ZED_FILE"],
+    "tags": ["brownie", "test", "file"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+  {
+    "label": "brownie test: all tests",
+    "command": "brownie",
+    "args": ["test"],
+    "tags": ["brownie", "test", "all"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+
+  // ============================================================================
+  // SECURITY & LINTING TOOLS
+  // ============================================================================
+  {
+    "label": "slither: analyze symbol",
+    "command": "slither",
+    "args": ["$ZED_FILE"],
+    "tags": ["security", "slither", "symbol"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+  {
+    "label": "slither: analyze contract",
+    "command": "slither",
+    "args": ["$ZED_FILE"],
+    "tags": ["security", "slither", "contract"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+  {
+    "label": "slither: analyze current file",
+    "command": "slither",
+    "args": ["$ZED_FILE"],
+    "tags": ["security", "slither", "file"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+  {
+    "label": "slither: analyze all",
+    "command": "slither",
+    "args": ["."],
+    "tags": ["security", "slither", "all"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+
+  {
+    "label": "solhint: lint symbol",
+    "command": "solhint",
+    "args": ["$ZED_FILE"],
+    "tags": ["linting", "solhint", "symbol"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+  {
+    "label": "solhint: lint contract",
+    "command": "solhint",
+    "args": ["$ZED_FILE"],
+    "tags": ["linting", "solhint", "contract"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+  {
+    "label": "solhint: lint current file",
+    "command": "solhint",
+    "args": ["$ZED_FILE"],
+    "tags": ["linting", "solhint", "file"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+  {
+    "label": "solhint: lint all",
+    "command": "solhint",
+    "args": ["'contracts/**/*.sol'"],
+    "tags": ["linting", "solhint", "all"],
+    "reveal": "always",
+    "use_new_terminal": false
+  }
+]

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -218,7 +218,7 @@
   {
     "label": "solhint: lint all",
     "command": "solhint",
-    "args": ["'contracts/**/*.sol'"],
+    "args": ["contracts/**/*.sol"],
     "tags": ["linting", "solhint", "all"],
     "reveal": "always",
     "use_new_terminal": false

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -18,7 +18,7 @@
     "label": "forge test: $ZED_SYMBOL",
     "command": "forge",
     "args": ["test", "--match-test", "$ZED_SYMBOL", "-vvvvv"],
-    "tags": ["foundry", "test", "symbol"],
+    "tags": ["solidity-test"],
     "reveal": "always",
     "use_new_terminal": false
   },
@@ -26,7 +26,7 @@
     "label": "forge test: $ZED_SYMBOL (contract)",
     "command": "forge",
     "args": ["test", "--match-contract", "$ZED_SYMBOL", "-vvvvv"],
-    "tags": ["foundry", "test", "contract"],
+    "tags": ["solidity-contract-test"],
     "reveal": "always",
     "use_new_terminal": false
   },
@@ -34,7 +34,7 @@
     "label": "forge test: current file",
     "command": "forge",
     "args": ["test", "--match-path", "$ZED_FILE", "-vvvvv"],
-    "tags": ["foundry", "test", "file"],
+    "tags": ["solidity-test", "solidity-contract-test"],
     "reveal": "always",
     "use_new_terminal": false
   },
@@ -42,7 +42,7 @@
     "label": "forge test: all tests",
     "command": "forge",
     "args": ["test", "-vvvvv"],
-    "tags": ["foundry", "test", "all"],
+    "tags": ["solidity-test", "solidity-contract-test"],
     "reveal": "always",
     "use_new_terminal": false
   },
@@ -51,18 +51,18 @@
   // HARDHAT
   // ============================================================================
   {
-    "label": "hardhat test: test by name",
+    "label": "hardhat test: $ZED_SYMBOL",
     "command": "npx",
     "args": ["hardhat", "test", "--grep", "$ZED_SYMBOL"],
-    "tags": ["hardhat", "test", "symbol"],
+    "tags": ["solidity-test"],
     "reveal": "always",
     "use_new_terminal": false
   },
   {
-    "label": "hardhat test: contract tests",
+    "label": "hardhat test: $ZED_SYMBOL (contract)",
     "command": "npx",
     "args": ["hardhat", "test", "--grep", "$ZED_SYMBOL"],
-    "tags": ["hardhat", "test", "contract"],
+    "tags": ["solidity-contract-test"],
     "reveal": "always",
     "use_new_terminal": false
   },
@@ -70,7 +70,7 @@
     "label": "hardhat test: current file",
     "command": "npx",
     "args": ["hardhat", "test", "$ZED_FILE"],
-    "tags": ["hardhat", "test", "file"],
+    "tags": ["solidity-test", "solidity-contract-test"],
     "reveal": "always",
     "use_new_terminal": false
   },
@@ -78,7 +78,7 @@
     "label": "hardhat test: all tests",
     "command": "npx",
     "args": ["hardhat", "test"],
-    "tags": ["hardhat", "test", "all"],
+    "tags": ["solidity-test", "solidity-contract-test"],
     "reveal": "always",
     "use_new_terminal": false
   },
@@ -87,18 +87,18 @@
   // TRUFFLE
   // ============================================================================
   {
-    "label": "truffle test: test by name",
+    "label": "truffle test: $ZED_SYMBOL",
     "command": "truffle",
     "args": ["test", "--grep", "$ZED_SYMBOL"],
-    "tags": ["truffle", "test", "symbol"],
+    "tags": ["solidity-test"],
     "reveal": "always",
     "use_new_terminal": false
   },
   {
-    "label": "truffle test: contract tests",
+    "label": "truffle test: $ZED_SYMBOL (contract)",
     "command": "truffle",
     "args": ["test", "--grep", "$ZED_SYMBOL"],
-    "tags": ["truffle", "test", "contract"],
+    "tags": ["solidity-contract-test"],
     "reveal": "always",
     "use_new_terminal": false
   },
@@ -106,7 +106,7 @@
     "label": "truffle test: current file",
     "command": "truffle",
     "args": ["test", "$ZED_FILE"],
-    "tags": ["truffle", "test", "file"],
+    "tags": ["solidity-test", "solidity-contract-test"],
     "reveal": "always",
     "use_new_terminal": false
   },
@@ -114,7 +114,7 @@
     "label": "truffle test: all tests",
     "command": "truffle",
     "args": ["test"],
-    "tags": ["truffle", "test", "all"],
+    "tags": ["solidity-test", "solidity-contract-test"],
     "reveal": "always",
     "use_new_terminal": false
   },
@@ -123,18 +123,18 @@
   // BROWNIE
   // ============================================================================
   {
-    "label": "brownie test: test by name",
+    "label": "brownie test: $ZED_SYMBOL",
     "command": "brownie",
     "args": ["test", "-k", "$ZED_SYMBOL"],
-    "tags": ["brownie", "test", "symbol"],
+    "tags": ["solidity-test"],
     "reveal": "always",
     "use_new_terminal": false
   },
   {
-    "label": "brownie test: contract tests",
+    "label": "brownie test: $ZED_SYMBOL (contract)",
     "command": "brownie",
     "args": ["test", "-k", "$ZED_SYMBOL"],
-    "tags": ["brownie", "test", "contract"],
+    "tags": ["solidity-contract-test"],
     "reveal": "always",
     "use_new_terminal": false
   },
@@ -142,7 +142,7 @@
     "label": "brownie test: current file",
     "command": "brownie",
     "args": ["test", "$ZED_FILE"],
-    "tags": ["brownie", "test", "file"],
+    "tags": ["solidity-test", "solidity-contract-test"],
     "reveal": "always",
     "use_new_terminal": false
   },
@@ -150,7 +150,7 @@
     "label": "brownie test: all tests",
     "command": "brownie",
     "args": ["test"],
-    "tags": ["brownie", "test", "all"],
+    "tags": ["solidity-test", "solidity-contract-test"],
     "reveal": "always",
     "use_new_terminal": false
   },
@@ -159,26 +159,10 @@
   // SECURITY & LINTING TOOLS
   // ============================================================================
   {
-    "label": "slither: analyze symbol",
-    "command": "slither",
-    "args": ["$ZED_FILE"],
-    "tags": ["security", "slither", "symbol"],
-    "reveal": "always",
-    "use_new_terminal": false
-  },
-  {
-    "label": "slither: analyze contract",
-    "command": "slither",
-    "args": ["$ZED_FILE"],
-    "tags": ["security", "slither", "contract"],
-    "reveal": "always",
-    "use_new_terminal": false
-  },
-  {
     "label": "slither: analyze current file",
     "command": "slither",
     "args": ["$ZED_FILE"],
-    "tags": ["security", "slither", "file"],
+    "tags": ["solidity-test", "solidity-contract-test"],
     "reveal": "always",
     "use_new_terminal": false
   },
@@ -186,32 +170,16 @@
     "label": "slither: analyze all",
     "command": "slither",
     "args": ["."],
-    "tags": ["security", "slither", "all"],
+    "tags": ["solidity-test", "solidity-contract-test"],
     "reveal": "always",
     "use_new_terminal": false
   },
 
   {
-    "label": "solhint: lint symbol",
-    "command": "solhint",
-    "args": ["$ZED_FILE"],
-    "tags": ["linting", "solhint", "symbol"],
-    "reveal": "always",
-    "use_new_terminal": false
-  },
-  {
-    "label": "solhint: lint contract",
-    "command": "solhint",
-    "args": ["$ZED_FILE"],
-    "tags": ["linting", "solhint", "contract"],
-    "reveal": "always",
-    "use_new_terminal": false
-  },
-  {
     "label": "solhint: lint current file",
     "command": "solhint",
     "args": ["$ZED_FILE"],
-    "tags": ["linting", "solhint", "file"],
+    "tags": ["solidity-test", "solidity-contract-test"],
     "reveal": "always",
     "use_new_terminal": false
   },
@@ -219,7 +187,7 @@
     "label": "solhint: lint all",
     "command": "solhint",
     "args": ["contracts/**/*.sol"],
-    "tags": ["linting", "solhint", "all"],
+    "tags": ["solidity-test", "solidity-contract-test"],
     "reveal": "always",
     "use_new_terminal": false
   }

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Example task that connect with the definitions in [runnables.scm](languages/soli
   {
     "label": "forge test: $ZED_SYMBOL (contract)",
     "command": "forge",
-    "args": [ "test", "--match-contract", "$ZED_SYMBOL", "-vvvvv", ],
-    "tags": [ "solidity-contract-test" ],
+    "args": ["test", "--match-contract", "$ZED_SYMBOL", "-vvvvv"],
+    "tags": ["solidity-contract-test"],
     "reveal": "always",
     "use_new_terminal": false
   }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,49 @@ Enhance Zed with Solidity language support, including syntax highlighting and la
 
 ---
 
+## Tasks
+
+Example tasks for different test frameworks can be found in [.zed/tasks.json](.zed/tasks.json).
+
+How to set up Foundry to run tests via a runnable (the play button next to tests
+in the UI) and via keyboard shortcut.
+
+Example task that connect with the definitions in [runnables.scm](languages/solidity/runnables.scm) via tags.
+```json
+[
+  // Individual test.
+  {
+    "label": "forge test: $ZED_SYMBOL",
+    "command": "forge",
+    "args": ["test", "--match-test", "$ZED_SYMBOL", "-vvvvv"],
+    "tags": ["solidity-test"],
+    "reveal": "always",
+    "use_new_terminal": false
+  },
+  // Contract test.
+  {
+    "label": "forge test: $ZED_SYMBOL (contract)",
+    "command": "forge",
+    "args": [ "test", "--match-contract", "$ZED_SYMBOL", "-vvvvv", ],
+    "tags": [ "solidity-contract-test" ],
+    "reveal": "always",
+    "use_new_terminal": false
+  }
+]
+```
+
+Example keymap to run Forge test for the symbol under the cursor.
+```json
+[
+  {
+    "context": "Editor && extension==sol",
+    "bindings": {
+      "alt-g": ["task::Spawn", { "task_name": "forge test: $ZED_SYMBOL" }]
+    }
+  }
+]
+```
+
 ## 🛠️ Development Setup
 
 ### 1. Clone the repository

--- a/code/example.test.sol
+++ b/code/example.test.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+import "./example.sol";
+
+contract ComprehensiveExampleTest is Test {
+    ComprehensiveExample public token;
+    address public owner;
+    address public alice;
+    address public bob;
+    uint256 public constant INITIAL_SUPPLY = 1_000_000e18;
+
+    // Events to test against
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    function setUp() public {
+        // validAddress modifier checks for address(0), so we set a real owner
+        owner = address(this);
+        alice = makeAddr("alice");
+        bob = makeAddr("bob");
+
+        // Deploy the contract with initial supply and owner
+        token = new ComprehensiveExample(INITIAL_SUPPLY, owner);
+    }
+
+    function test_InitialState() public {
+        assertEq(token.totalSupply(), INITIAL_SUPPLY);
+        assertEq(token.balanceOf(owner), INITIAL_SUPPLY);
+        assertEq(token.owner(), owner);
+        console.log("stuff!!!");
+    }
+
+    function test_Transfer() public {
+        uint256 amount = 1000e18;
+
+        // Owner transfers to Alice
+        token.transfer(alice, amount);
+
+        assertEq(token.balanceOf(alice), amount);
+        assertEq(token.balanceOf(owner), INITIAL_SUPPLY - amount);
+    }
+
+    function test_Transfer_EmitEvent() public {
+        uint256 amount = 500e18;
+
+        vm.expectEmit(true, true, false, true);
+        emit Transfer(owner, alice, amount);
+
+        token.transfer(alice, amount);
+    }
+
+    function test_Mint_AsOwner() public {
+        uint256 amount = 500e18;
+
+        token.mint(alice, amount);
+
+        assertEq(token.balanceOf(alice), amount);
+        assertEq(token.totalSupply(), INITIAL_SUPPLY + amount);
+    }
+
+    function test_RevertWhen_MintNotOwner() public {
+        uint256 amount = 500e18;
+
+        // Prank Alice (make next call come from Alice)
+        vm.prank(alice);
+
+        // Expect the "Not the owner" require message from onlyOwner modifier
+        vm.expectRevert("Not the owner");
+        token.mint(alice, amount);
+    }
+
+    function test_Burn() public {
+        uint256 burnAmount = 100e18;
+
+        token.burn(burnAmount);
+
+        assertEq(token.totalSupply(), INITIAL_SUPPLY - burnAmount);
+        assertEq(token.balanceOf(owner), INITIAL_SUPPLY - burnAmount);
+    }
+
+    function test_RevertWhen_BurnInsufficientBalance() public {
+        uint256 burnAmount = INITIAL_SUPPLY + 1;
+
+        // Expect the custom error InsufficientBalance(requested, available)
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ComprehensiveExample.InsufficientBalance.selector,
+                burnAmount,
+                INITIAL_SUPPLY
+            )
+        );
+        token.burn(burnAmount);
+    }
+
+    // Fuzz testing example
+    function testFuzz_Transfer(uint256 amount) public {
+        // Constrain fuzz inputs to valid amounts
+        vm.assume(amount > 0 && amount <= INITIAL_SUPPLY);
+
+        token.transfer(alice, amount);
+        assertEq(token.balanceOf(alice), amount);
+    }
+}

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "solidity"
 name = "Solidity"
-version = "0.1.9"
+version = "0.2.2"
 schema_version = 1
 authors = ["Daniel Zarifpour <z@rifpour.xyz>"]
 description = "💠 Solidity language support for Zed. ✰ and report issues ➩"

--- a/languages/solidity/runnables.scm
+++ b/languages/solidity/runnables.scm
@@ -1,17 +1,28 @@
 ; Solidity test function detection for Zed editor
-; Detects functions starting with "test" or "testFail" in contract declarations
 
-; Match test functions (test*, testFail*, invariant*)
+; Match test functions (test*, testFail*, testFuzz*, invariant*)
 (
-  (function_definition
-    name: (identifier) @run
-    (#match? @run "^(test_)")
-    (#set! tag solidity-test))
+  (
+    (function_definition
+      name: (identifier) @run
+      (#match? @run "^test"))
+  ) @_
+  (#set! tag solidity-test)
+)
+
+(
+  (
+    (function_definition
+      name: (identifier) @run
+      (#match? @run "^invariant"))
+  ) @_
+  (#set! tag solidity-test)
 )
 
 ; Match entire contract for running all tests in a contract
 (
   (contract_declaration
-    name: (identifier) @run)
+    name: (identifier) @run
+  ) @_
   (#set! tag solidity-contract-test)
 )

--- a/languages/solidity/runnables.scm
+++ b/languages/solidity/runnables.scm
@@ -1,0 +1,17 @@
+; Solidity test function detection for Zed editor
+; Detects functions starting with "test" or "testFail" in contract declarations
+
+; Match test functions (test*, testFail*, invariant*)
+(
+  (function_definition
+    name: (identifier) @run
+    (#match? @run "^(test_)")
+    (#set! tag solidity-test))
+)
+
+; Match entire contract for running all tests in a contract
+(
+  (contract_declaration
+    name: (identifier) @run)
+  (#set! tag solidity-contract-test)
+)


### PR DESCRIPTION
Add runnables.scm for detecting tests and add examples to the README for how to connect tasks with tags from runnables.scm and how to add keyboard shortcut to run the test under the cursor.

The foundry tasks have been tested, the others were generated so they may or may not work. They serve as useful examples though.

When testing it if you get `Nothing to compile` when running a test via the play button in the UI or the keyboard shortcut it means the mapping is working 👍 To get things to actually work we'd have to set up Foundry in the repo and I'm not sure that is helpful since there are many testing frameworks for Solidity. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Tasks section to the README with example task templates and development setup steps.

* **Examples**
  * Added a comprehensive Solidity test example exercising state, transfers, events, mint/burn, revert cases, and fuzzed transfers.

* **New Features**
  * Added editor task templates for running tests and analysis across multiple frameworks and enhanced Solidity test discovery to detect individual test functions and contract-wide tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->