### PR TITLE
feat: add comment injection for solidity

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "solidity"
 name = "Solidity"
-version = "0.1.9"
+version = "0.2.1"
 schema_version = 1
 authors = ["Daniel Zarifpour <z@rifpour.xyz>"]
 description = "💠 Solidity language support for Zed. ✰ and report issues ➩"

--- a/languages/solidity/injections.scm
+++ b/languages/solidity/injections.scm
@@ -1,0 +1,2 @@
+((comment) @content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
# Summary:

  - Add `injections.scm` to enable comment injection for Solidity. Works in pair with z[ed-comment](https://github.com/thedadams/zed-comment) extension
  
  
 
##  Context: 
  
-  Followed [zed-comment's instructions](https://github.com/thedadams/zed-comment?tab=readme-ov-file#2-find-or-create-the-injectionsscm-file-for-the-desired-language) and added the necessary file to enable comment highlighting. 
  
  
  ## (Manual) Test: 
  
- Here's what this gives: 

<img width="706" height="129" alt="Zed 2026-02-10 20 19 01" src="https://github.com/user-attachments/assets/3f1376ef-ea3b-4a6c-b504-f62471821313" />

<img width="571" height="391" alt="Zed 2026-02-10 20 19 41" src="https://github.com/user-attachments/assets/2f829b2c-9d83-4665-8200-60743c7f1df3" />

  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Solidity comment handling: added a static injection that maps content tagged as comments to be treated as comment text, improving syntax highlighting and code processing accuracy.
* **Chores**
  * Release updated to version 0.2.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->